### PR TITLE
Adding support for value-encoding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ const { WriteStream, ReadStream } = require('hypercore-streams')
 const ws = new WriteStream(feed)
 const rs = new ReadStream(feed, {
   start: 0,
-  live: true
+  live: true,
+  valueEncoding: 'json'
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class ReadStream extends Readable {
     this.snapshot = opts.snapshot !== false
     this.tail = !!opts.tail
     this.index = this.start
-    this.options = { wait: opts.wait !== false, ifAvailable: !!opts.ifAvailable }
+    this.options = { wait: opts.wait !== false, ifAvailable: !!opts.ifAvailable, valueEncoding: opts.valueEncoding }
   }
 
   _open (cb) {

--- a/test.js
+++ b/test.js
@@ -69,3 +69,19 @@ tape('basic writestream', function (t) {
     })
   })
 })
+
+tape('valueEncoding test', function (t) {
+  const feed = hypercore(ram, { valueEncoding: 'json' })
+
+  feed.append(['a', 'b', 'c'], function () {
+    const rs = new ReadStream(feed, { valueEncoding: 'buffer' })
+    const expected = ['a', 'b', 'c']
+
+    rs.on('data', function (data) {
+      t.same(data, Buffer.from('"' + expected.shift() + '"\n'))
+    })
+    rs.on('end', function () {
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
The `valueEncoding` option for the streams is required for using this module as a replacement for hypercore streams.